### PR TITLE
Inline assume to avoid performance regression

### DIFF
--- a/src/stable/mod.rs
+++ b/src/stable/mod.rs
@@ -13,6 +13,7 @@ pub mod vec;
 mod macros;
 
 #[track_caller]
+#[inline(always)]
 #[cfg(debug_assertions)]
 unsafe fn assume(v: bool) {
     if !v {
@@ -20,6 +21,7 @@ unsafe fn assume(v: bool) {
     }
 }
 
+#[inline(always)]
 #[cfg(not(debug_assertions))]
 unsafe fn assume(v: bool) {
     if !v {


### PR DESCRIPTION
The intrinsic assume is called in a lot of hot paths throughout alloc. It should not compiled to any code and just inform optimizations, however the stable polyfill is apparently not inlined enough as can be seen while profiling some some simple vector operations.

This commit improves the performance of a benchmark using Vec a fair amount although it does not quite achieves the performance of using the standard Vec.

The benchmark is question is lyon's tessellator. I've been musing with the idea of making it possible to use a custom allocator.

Here are some profiles of lyon's tessellation benchmarks using allocator-api2 with the default allocator:
 - [Before](https://share.firefox.dev/3LPyALE) (You can see `assume` popping up in places),
 - [After](https://share.firefox.dev/3JDYXS2).

## Benchmark results:

Before this commit:
```
test fill_events_01_logo                ... bench:      47,906 ns/iter (+/- 197)
test fill_events_02_logo_pre_flattened  ... bench:      31,724 ns/iter (+/- 389)
test fill_events_03_logo_with_tess      ... bench:     114,658 ns/iter (+/- 328)
test fill_tess_01_logo                  ... bench:      97,841 ns/iter (+/- 675)
test fill_tess_03_logo_no_intersections ... bench:     107,294 ns/iter (+/- 507)
test fill_tess_05_logo_no_curve         ... bench:      45,928 ns/iter (+/- 268)
test fill_tess_06_logo_with_ids         ... bench:      96,941 ns/iter (+/- 2,902)
```


After this commit:
```
test fill_events_01_logo                ... bench:      36,828 ns/iter (+/- 955)
test fill_events_02_logo_pre_flattened  ... bench:      22,335 ns/iter (+/- 894)
test fill_events_03_logo_with_tess      ... bench:      91,138 ns/iter (+/- 4,077)
test fill_tess_01_logo                  ... bench:      75,015 ns/iter (+/- 850)
test fill_tess_03_logo_no_intersections ... bench:      84,519 ns/iter (+/- 1,408)
test fill_tess_05_logo_no_curve         ... bench:      35,990 ns/iter (+/- 674)
test fill_tess_06_logo_with_ids         ... bench:      74,008 ns/iter (+/- 1,486)
```

Using the standard vec without allocator-api2:
```
test fill_events_01_logo                ... bench:      31,069 ns/iter (+/- 1,645)
test fill_events_02_logo_pre_flattened  ... bench:      15,140 ns/iter (+/- 254)
test fill_events_03_logo_with_tess      ... bench:      71,495 ns/iter (+/- 2,302)
test fill_tess_01_logo                  ... bench:      56,456 ns/iter (+/- 1,519)
test fill_tess_03_logo_no_intersections ... bench:      67,282 ns/iter (+/- 625)
test fill_tess_05_logo_no_curve         ... bench:      28,458 ns/iter (+/- 87)
test fill_tess_06_logo_with_ids         ... bench:      55,699 ns/iter (+/- 1,516)
```