### PR TITLE
chore: Set `rust-version` in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/zakarumych/allocator-api2"
 repository = "https://github.com/zakarumych/allocator-api2"
 readme = "README.md"
 description = "Mirror of Rust's allocator API"
+rust-version = "1.63.0"
 
 [features]
 alloc = []


### PR DESCRIPTION
Maintaining an appropriate `rust-version` will better support downstreams resolving dependencies with compatible releases via `-Z msrv-policy` (_or the eventual stabilized equivalent_).

---

### Context

Looks like the minimum supported version is Rust `1.63.0`, at least when opt-out of the default features (`std`); otherwise it's Rust `1.64.0`.

For reference `hashbrown 0.14.2` release [relaxed their MSRV from `1.64.0` to `1.63`](https://github.com/rust-lang/hashbrown/commit/35e6124af159ce483991fab1b79c14d6238b452d#diff-da0a9b3bf0317fc5ba5c008f9a789601ae025f6e3e7451a0f9193e2ce22b38e7R20):
- Provided that this crate is pinned to `0.2.9` (_`0.2.10` is compatible too_) or the related default feature in hashbrown is disabled.
- This was to allow current [Debian stable to build `hashbrown` with Rust 1.63](https://github.com/rust-lang/hashbrown/pull/457#issue-1864074133).

In future, if this sort of change happens it could be better resolved if `rust-version` was adopted instead. Presently without updating `Cargo.lock` with a pin for `hashbrown`, the implicit `allocator-api2` dep will resolve to a version incompatible with `rust-version = "1.63.0"`, but `-Z msrv-policy` won't be able to infer that due to lack of `rust-version`.

---

`allocator-api2` should likewise adopt `rust-version`.
- `1.64.0` might go more smoothly in the ecosystem (**Preferred**).
- `1.63.0` is more accurate and may avoid adding friction.

If preferring `rust-version = "1.64.0"`, it should rollback to the prior release when this condition is not satisfied (eg: `-Z msrv-policy`). Thus only a concern if downstreams still expect to compile newer releases with `1.63.0`?

For context the `0.2.9` release was `1.63.0` regardless of `std` vs `nostd` builds below.

---

### Reproduction with `cargo-msrv`

<details>
<summary>std (default) => MSRV 1.64</summary>

```toml
[package]
name = "reproduction"
version = "0.1.0"
edition = "2021"

[dependencies]
allocator-api2 = "0.2.16"
```

```rs
fn main() {
    println!("Hello, world!");
}
```

```console
$ cargo-msrv --max 1.64.0

Check for toolchain '1.63.0-x86_64-unknown-linux-gnu' failed with:
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Checking allocator-api2 v0.2.16                                                                                                 │
│ error[E0658]: use of unstable library feature 'core_c_str'                                                                      │
│     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/boxed.rs:2115:20             │
│      |                                                                                                                          │
│ 2115 | impl Clone for Box<core::ffi::CStr> {                                                                                    │
│      |                    ^^^^^^^^^^^^^^^                                                                                       │
│      |                                                                                                                          │
│      = note: see issue #94079 <https://github.com/rust-lang/rust/issues/94079> for more information                             │
│                                                                                                                                 │
│ error[E0658]: use of unstable library feature 'core_c_str'                                                                      │
│     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/boxed.rs:2123:12             │
│      |                                                                                                                          │
│ 2123 | impl From<&core::ffi::CStr> for Box<core::ffi::CStr> {                                                                   │
│      |            ^^^^^^^^^^^^^^^                                                                                               │
│      |                                                                                                                          │
│      = note: see issue #94079 <https://github.com/rust-lang/rust/issues/94079> for more information                             │
│                                                                                                                                 │
│ error[E0658]: use of unstable library feature 'core_c_str'                                                                      │
│     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/boxed.rs:2123:37             │
│      |                                                                                                                          │
│ 2123 | impl From<&core::ffi::CStr> for Box<core::ffi::CStr> {                                                                   │
│      |                                     ^^^^^^^^^^^^^^^                                                                      │
│      |                                                                                                                          │
│      = note: see issue #94079 <https://github.com/rust-lang/rust/issues/94079> for more information                             │
│                                                                                                                                 │
│ error[E0658]: use of unstable library feature 'core_c_str'                                                                      │
│     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/boxed.rs:2126:17             │
│      |                                                                                                                          │
│ 2126 |     fn from(s: &core::ffi::CStr) -> Box<core::ffi::CStr> {                                                               │
│      |                 ^^^^^^^^^^^^^^^                                                                                          │
│      |                                                                                                                          │
│      = note: see issue #94079 <https://github.com/rust-lang/rust/issues/94079> for more information                             │
│                                                                                                                                 │
│ error[E0658]: use of unstable library feature 'core_c_str'                                                                      │
│     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/boxed.rs:2126:41             │
│      |                                                                                                                          │
│ 2126 |     fn from(s: &core::ffi::CStr) -> Box<core::ffi::CStr> {                                                               │
│      |                                         ^^^^^^^^^^^^^^^                                                                  │
│      |                                                                                                                          │
│      = note: see issue #94079 <https://github.com/rust-lang/rust/issues/94079> for more information                             │
│                                                                                                                                 │
│ error[E0658]: use of unstable library feature 'core_c_str'                                                                      │
│     --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/boxed.rs:2128:61             │
│      |                                                                                                                          │
│ 2128 |         unsafe { Box::from_raw(Box::into_raw(boxed) as *mut core::ffi::CStr) }                                           │
│      |                                                             ^^^^^^^^^^^^^^^                                              │
│      |                                                                                                                          │
│      = note: see issue #94079 <https://github.com/rust-lang/rust/issues/94079> for more information                             │
│                                                                                                                                 │
│ For more information about this error, try `rustc --explain E0658`.                                                             │
│ error: could not compile `allocator-api2` due to 6 previous errors                                                              │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
Check for toolchain '1.64.0-x86_64-unknown-linux-gnu' succeeded
   Finished The MSRV is: 1.64.0   ████████████████████████████████████████████████████████████████████████████████████████ 00:00:01
```

</details>

---

<details>
<summary>nostd (default-features = false) => MSRV 1.63</summary>

```toml
[package]
name = "reproduction"
version = "0.1.0"
edition = "2021"

[dependencies]
# opt-out of default `std` feature:
allocator-api2 = { version = "0.2.16", default-features = false }
```

```rs
#![no_main]
#![no_std]

use core::panic::PanicInfo;

#[panic_handler]
fn panic(_panic: &PanicInfo<'_>) -> ! {
    loop {}
}
```

```console
# Make cargo-msrv happy:
$ rustup target add x86_64-unknown-none
$ rustup target add --toolchain 1.64.0 x86_64-unknown-none
$ rustup target add --toolchain 1.63.0 x86_64-unknown-none
$ rustup target add --toolchain 1.62.1 x86_64-unknown-none

# Verify:
$ cargo-msrv --max 1.64.0 -- cargo check --target x86_64-unknown-none

Check for toolchain '1.62.1-x86_64-unknown-linux-gnu' failed with:
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Checking allocator-api2 v0.2.16                                                                                                 │
│ error[E0658]: use of unstable library feature 'slice_ptr_len'                                                                   │
│    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/allocator-api2-0.2.16/src/stable/alloc/mod.rs:143:63           │
│     |                                                                                                                           │
│ 143 |         unsafe { ptr.cast::<u8>().as_ptr().write_bytes(0, ptr.len()) }                                                    │
│     |                                                               ^^^                                                         │
│     |                                                                                                                           │
│     = note: see issue #71146 <https://github.com/rust-lang/rust/issues/71146> for more information                              │
│                                                                                                                                 │
│ For more information about this error, try `rustc --explain E0658`.                                                             │
│ error: could not compile `allocator-api2` due to previous error                                                                 │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
Check for toolchain '1.63.0-x86_64-unknown-linux-gnu' succeeded
   Finished The MSRV is: 1.63.0   ████████████████████████████████████████████████████████████████████████████████████████ 00:00:01
```

</details>