### PR TITLE
Made TryReserveError & TryReserveErrorKind public to make Vec::try_reserve possible to use

### DIFF
--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -2,4 +2,4 @@
 pub use core::alloc;
 
 #[cfg(feature = "alloc")]
-pub use alloc_crate::{alloc, boxed, vec};
+pub use alloc_crate::{alloc, boxed, vec, collections};

--- a/src/stable/mod.rs
+++ b/src/stable/mod.rs
@@ -22,6 +22,11 @@ mod macros;
 mod slice;
 
 #[cfg(feature = "alloc")]
+pub mod collections {
+    pub use super::raw_vec::{TryReserveError, TryReserveErrorKind};
+}
+
+#[cfg(feature = "alloc")]
 #[track_caller]
 #[inline(always)]
 #[cfg(debug_assertions)]


### PR DESCRIPTION
If Vec::try_reserve is a public method, then its error type also should be public.