### PR TITLE
Added: Nightly implementation (or lack of) for unsize_box

### DIFF
--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -3,3 +3,34 @@ pub use core::alloc;
 
 #[cfg(feature = "alloc")]
 pub use alloc_crate::{alloc, boxed, vec, collections};
+
+/// # Note
+/// 
+/// This is a no-op on nightly. This macro is a stub, to ensure no build errors when switching
+/// between nightly and stable. `std` does the conversion automatically.
+/// 
+/// # Summary
+/// 
+/// Allows turning a [`Box<T: Sized, A>`][boxed::Box] into a [`Box<U: ?Sized, A>`][boxed::Box] where `T` can be unsizing-coerced into a `U`.
+/// 
+/// This is the only way to create an `allocator_api2::boxed::Box` of an unsized type on stable.
+///
+/// With the standard library's `alloc::boxed::Box`, this is done automatically using the unstable unsize traits, but this crate's Box
+/// can't take advantage of that machinery on stable. So, we need to use type inference and the fact that you *can*
+/// still coerce the inner pointer of a box to get the compiler to help us unsize it using this macro.
+///
+/// # Example
+///
+/// ```
+/// use allocator_api2::unsize_box;
+/// use allocator_api2::boxed::Box;
+/// use core::any::Any;
+///
+/// let sized_box: Box<u64> = Box::new(0);
+/// let unsized_box: Box<dyn Any> = unsize_box!(sized_box);
+/// ```
+#[macro_export]
+#[cfg(feature = "alloc")]
+macro_rules! unsize_box {( $boxed:expr $(,)? ) => ({
+    $boxed
+})}


### PR DESCRIPTION
This PR is related to:
- https://github.com/zakarumych/allocator-api2/pull/6

There is currently no `nightly` declaration of the `unsize_box`, so projects fail to build if the `nightly` feature is enabled. This adds a stub for `unsize_box`; no actual implementation is needed, since with `std`, the compiler can automatically perform the conversion.

