### PR TITLE
fix unsafe autoref lint error

### DIFF
--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1980,7 +1980,7 @@ impl<T, A: Allocator> Vec<T, A> {
     #[cfg(not(no_global_oom_handling))]
     #[inline(always)]
     unsafe fn append_elements(&mut self, other: *const [T]) {
-        let count = unsafe { (*other).len() };
+        let count = other.len();
         self.reserve(count);
         let len = self.len();
         unsafe { ptr::copy_nonoverlapping(other as *const T, self.as_mut_ptr().add(len), count) };


### PR DESCRIPTION
This fixes a new deny-by-default lint that was added in Rust 1.88